### PR TITLE
Batch PubSub Scraping

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
 
   cloud-tasks:
     image: ghcr.io/aertje/cloud-tasks-emulator:latest
-    command: -host 0.0.0.0 -port 8123 -queue "projects/test-project/locations/here/queues/test-book-queue"
+    command: -host 0.0.0.0 -port 8123 -queue "projects/test-project/locations/here/queues/test-queue"
     ports:
       - "${TASKS_PORT:-8123}:8123"
 

--- a/src/clients/api_models.py
+++ b/src/clients/api_models.py
@@ -41,11 +41,29 @@ class BookV1ApiRequest(BaseModel):
             return str(input_datetime)
 
 
-class UserReviewV1ApiRequest(BaseModel):
+class UserReviewV1BatchItem(BaseModel):
+    user_id: int
+    book_id: int
     user_rating: int
     date_read: str
     scrape_time: str
 
-    @validator("date_read", "scrape_time", pre=True)
-    def convert_date_read_to_string(cls, input_datetime):
-        return str(input_datetime.isoformat())
+
+class UserReviewV1BatchRequest(BaseModel):
+    user_reviews: List[UserReviewV1BatchItem]
+
+
+class ApiBookExistsBatchRequest(BaseModel):
+    book_ids: List[int]
+
+
+class ApiBookExistsBatchResponse(BaseModel):
+    book_ids: List[int]
+
+
+class ApiUserReviewBatchResponse(BaseModel):
+    indexed: int
+
+
+class UserReviewBatchResponse(BaseModel):
+    indexed: int

--- a/src/clients/api_models.py
+++ b/src/clients/api_models.py
@@ -48,6 +48,14 @@ class UserReviewV1BatchItem(BaseModel):
     date_read: str
     scrape_time: str
 
+    @validator("date_read", "scrape_time", pre=True, allow_reuse=True)
+    def convert_dates_and_times_to_strings(cls, input_datetime):
+        if input_datetime and isinstance(input_datetime, datetime):
+            # httpx doesn't like datetime objects in its json serializer
+            return str(input_datetime.isoformat())
+        else:
+            return str(input_datetime)
+
 
 class UserReviewV1BatchRequest(BaseModel):
     user_reviews: List[UserReviewV1BatchItem]

--- a/src/routes/pubsub_books.py
+++ b/src/routes/pubsub_books.py
@@ -51,7 +51,7 @@ async def handle_pubsub_message(
             try:
                 serialized_book = PubSubBookV1(**book)
             except ValidationError as e:
-                logging.error("Error converting profile into PubSubBookV1 object. Received: %s Error: %s", book, e)
+                logging.error("Error converting item into PubSubBookV1 object. Received: %s Error: %s", book, e)
                 continue
 
             await client.create_book(serialized_book.dict())

--- a/src/routes/pubsub_models.py
+++ b/src/routes/pubsub_models.py
@@ -75,3 +75,8 @@ class PubSubProfileV1(BaseModel):
 
 class PubSubItemBatch(BaseModel):
     items: List[Dict[str, Any]]
+
+
+class IndexerResponse(BaseModel):
+    indexed: int = 0
+    tasks: List[str] = list()

--- a/src/routes/pubsub_models.py
+++ b/src/routes/pubsub_models.py
@@ -71,3 +71,7 @@ class PubSubUserReviewV1(BaseModel):
 
 class PubSubProfileV1(BaseModel):
     user_id: str
+
+
+class PubSubItemBatch(BaseModel):
+    items: List[Dict[str, Any]]

--- a/src/routes/pubsub_profiles.py
+++ b/src/routes/pubsub_profiles.py
@@ -1,13 +1,12 @@
-import base64
-import json
 import logging
-from json import JSONDecodeError
+from typing import List
 
 from fastapi import APIRouter, Depends
 from pydantic import ValidationError, BaseModel
 
 from src.clients.task_client import get_task_client, TaskClient
 from src.routes.pubsub_models import PubSubMessage, PubSubProfileV1
+from src.routes.pubsub_utils import _unpack_envelope
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/pubsub/profiles")
@@ -30,7 +29,7 @@ The message pubsub sends us roughly follows this schema - data is base 64 encode
 
 
 class ProfileScrapeResponse(BaseModel):
-    task_name: str = None
+    tasks: List[str] = list()
 
 
 @router.post("/handle", tags=["profiles"], status_code=200)
@@ -45,21 +44,19 @@ async def handle_pubsub_message(
     Malformed messages will automatically get a 422 response from fastapi. However, if the message is well
     formed, but doesn't follow our model, we "ack" it with a 200, but discard the bad payload
     """
-    logging.debug("Handling message with ID %s - Publish Time %s - Attributes %s", request.message.message_id,
-                  request.message.publish_time, request.message.attributes)
-
     response = ProfileScrapeResponse()
-    try:
-        payload = base64.b64decode(request.message.data).decode("utf-8")
-        json_payload = json.loads(payload)
-        profile = PubSubProfileV1(**json_payload)
-        logging.info("Attempting to enqueue profile: %s", profile.user_id)
-        response.task_name = task_client.enqueue_user_scrape(profile.user_id)
-    except JSONDecodeError as _:
-        logging.error("Payload was not in JSON - received %s", payload)
-    except ValidationError as e:
-        logging.error("Error converting payload into profiles object. Received: %s Error: %s", json_payload, e)
-    except Exception as e:
-        logging.error("Uncaught Exception while handling pubsub message. Exception: %s. Message: %s", e, request.dict())
+    tasks = []
 
+    profile_batch = _unpack_envelope(request)
+    for profile in profile_batch.items:
+        try:
+            serialized_profile = PubSubProfileV1(**profile)
+        except ValidationError as e:
+            logging.error("Error converting profile into PubSubProfileV1 object. Received: %s Error: %s", profile, e)
+            continue
+        logging.info("Attempting to enqueue profile: %s", serialized_profile.user_id)
+        task_name = task_client.enqueue_user_scrape(serialized_profile.user_id)
+        tasks.append(task_name)
+
+    response.tasks = tasks
     return response

--- a/src/routes/pubsub_profiles.py
+++ b/src/routes/pubsub_profiles.py
@@ -48,7 +48,7 @@ async def handle_pubsub_message(
         try:
             serialized_profile = PubSubProfileV1(**profile)
         except ValidationError as e:
-            logging.error("Error converting profile into PubSubProfileV1 object. Received: %s Error: %s", profile, e)
+            logging.error("Error converting item into PubSubProfileV1 object. Received: %s Error: %s", profile, e)
             continue
         logging.info("Attempting to enqueue profile: %s", serialized_profile.user_id)
         task_name = task_client.enqueue_user_scrape(serialized_profile.user_id)

--- a/src/routes/pubsub_utils.py
+++ b/src/routes/pubsub_utils.py
@@ -1,0 +1,31 @@
+import base64
+import json
+import logging
+from json import JSONDecodeError
+
+from pydantic import ValidationError
+
+from src.routes.pubsub_models import PubSubItemBatch, PubSubMessage
+
+
+def _unpack_envelope(request: PubSubMessage) -> PubSubItemBatch:
+    """Unpacks an envelope from a Pub/Sub message.
+
+    Args:
+        envelope (dict): The Pub/Sub message, and all of its weird base64 data fields
+
+    Returns:
+        dict: The unpacked envelope into a nice python dict
+    """
+    logging.debug("Handling message with ID %s - Publish Time %s - Attributes %s", request.message.message_id,
+                  request.message.publish_time, request.message.attributes)
+    try:
+        payload = base64.b64decode(request.message.data).decode("utf-8")
+        json_payload = json.loads(payload)
+        return PubSubItemBatch(**json_payload)
+    except JSONDecodeError as _:
+        logging.error("Payload was not in JSON - received %s", payload)
+    except ValidationError as e:
+        logging.error("Error converting payload into profiles object. Received: %s Error: %s", json_payload, e)
+    except Exception as e:
+        logging.error("Uncaught Exception while handling pubsub message. Exception: %s. Message: %s", e, request.dict())

--- a/src/routes/pubsub_utils.py
+++ b/src/routes/pubsub_utils.py
@@ -26,6 +26,6 @@ def _unpack_envelope(request: PubSubMessage) -> PubSubItemBatch:
     except JSONDecodeError as _:
         logging.error("Payload was not in JSON - received %s", payload)
     except ValidationError as e:
-        logging.error("Error converting payload into profiles object. Received: %s Error: %s", json_payload, e)
+        logging.error("Error converting payload into object. Received: %s Error: %s", json_payload, e)
     except Exception as e:
         logging.error("Uncaught Exception while handling pubsub message. Exception: %s. Message: %s", e, request.dict())

--- a/src/services/user_review_service.py
+++ b/src/services/user_review_service.py
@@ -36,15 +36,10 @@ class UserReviewService(object):
             remaining_reviews_to_index = await self._remove_reviews_already_indexed(user_id, user_reviews)
 
             if len(remaining_reviews_to_index) > 0:
-                # First create the reviews
-                try:
-                    batch_user_reviews = [review.dict() for review in remaining_reviews_to_index]
-                    create_response = await self.book_recommender_api_client.create_batch_user_reviews(
-                        batch_user_reviews)
-                    service_response.indexed += create_response.indexed
-                except BookRecommenderApiClientException as e:
-                    logger.error("Received 4xx response from API - Failed to index user review: {}".format(e))
-                    return service_response
+                batch_user_reviews = [review.dict() for review in remaining_reviews_to_index]
+                create_response = await self.book_recommender_api_client.create_batch_user_reviews(
+                    batch_user_reviews)
+                service_response.indexed += create_response.indexed
                 # We intentionally allow 5xx and uncaught exceptions to bubble up to the caller
             else:
                 logger.info("All reviews for user_id: {} already indexed".format(user_id))

--- a/src/services/user_review_service.py
+++ b/src/services/user_review_service.py
@@ -1,11 +1,10 @@
 import logging
-from typing import List, Dict
 
 from fastapi import Depends
 from pydantic import BaseModel
+from typing import List, Dict
 
-from src.clients.book_recommender_api_client import BookRecommenderApiClient, get_book_recommender_api_client, \
-    BookRecommenderApiClientException
+from src.clients.book_recommender_api_client import BookRecommenderApiClient, get_book_recommender_api_client
 from src.clients.task_client import get_task_client, TaskClient
 from src.routes.pubsub_models import PubSubUserReviewV1
 
@@ -56,13 +55,12 @@ class UserReviewService(object):
 
     async def _remove_reviews_already_indexed(self, user_id,
                                               user_reviews: List[PubSubUserReviewV1]) -> List[PubSubUserReviewV1]:
-        candidates = user_reviews.copy()
+        reviews_to_index = user_reviews.copy()
         books_read_by_user = await self.book_recommender_api_client.get_books_read_by_user(user_id)
-        books_read_by_user_set = set(books_read_by_user)
-        for review in candidates:
-            if review.book_id in books_read_by_user_set:
-                candidates.remove(review)
-        return candidates
+        for review in user_reviews:
+            if review.book_id in books_read_by_user:
+                reviews_to_index.remove(review)
+        return reviews_to_index
 
     async def _remove_books_already_indexed(self, books_in_reviews: List[int]) -> List[int]:
         candidates = set(books_in_reviews.copy())

--- a/src/services/user_review_service.py
+++ b/src/services/user_review_service.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List, Dict
 
 from fastapi import Depends
 from pydantic import BaseModel
@@ -12,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 class UserReviewServiceResponse(BaseModel):
-    indexed_review: bool = False
-    task_name: str = None
+    indexed: int = 0
+    tasks: List[str] = []
 
 
 class UserReviewService(object):
@@ -21,33 +22,61 @@ class UserReviewService(object):
         self.book_recommender_api_client = book_recommender_api_client
         self.task_client = task_client
 
-    async def process_pubsub_message(self, pubsub_message: PubSubUserReviewV1) -> UserReviewServiceResponse:
-        response = UserReviewServiceResponse()
+    async def process_pubsub_batch_message(self, pubsub_message: List[PubSubUserReviewV1]) -> UserReviewServiceResponse:
+        service_response = UserReviewServiceResponse()
 
-        book_id = pubsub_message.book_id
-        user_id = pubsub_message.user_id
-        if await self._do_we_need_to_index_user_review(user_id, book_id):
-            try:
-                await self.book_recommender_api_client.create_user_review(pubsub_message.dict())
-                response.indexed_review = True
-            except BookRecommenderApiClientException as e:
-                logger.error("Received 4xx response from API - Failed to index user review: {}".format(e))
-                return response
-            # We intentionally allow 5xx and uncaught exceptions to bubble up to the caller
-        else:
-            logger.info("User review already indexed for user_id: {} and book_id: {}".format(
-                user_id, book_id))
+        # Partition by user ID - it should already be, but can't be too certain
+        user_to_review_batch_dict: Dict[int, List[PubSubUserReviewV1]] = {}
+        for user_review in pubsub_message:
+            if user_review.user_id not in user_to_review_batch_dict:
+                user_to_review_batch_dict[user_review.user_id] = []
+            user_to_review_batch_dict[user_review.user_id].append(user_review)
 
-        # If this is a new book, we should also trigger a background task to scrape it, but the user shouldn't wait
-        book_exists = await self.book_recommender_api_client.does_book_exist(book_id)
-        if not book_exists:
-            logging.info("Attempting to enqueue book_id: %s", book_id)
-            response.task_name = self.task_client.enqueue_book(book_id)
-        return response
+        for user_id, user_reviews in user_to_review_batch_dict.items():
+            remaining_reviews_to_index = await self._remove_reviews_already_indexed(user_id, user_reviews)
 
-    async def _do_we_need_to_index_user_review(self, user_id, book_id):
+            if len(remaining_reviews_to_index) > 0:
+                # First create the reviews
+                try:
+                    batch_user_reviews = [review.dict() for review in remaining_reviews_to_index]
+                    create_response = await self.book_recommender_api_client.create_batch_user_reviews(
+                        batch_user_reviews)
+                    service_response.indexed = create_response.indexed
+                except BookRecommenderApiClientException as e:
+                    logger.error("Received 4xx response from API - Failed to index user review: {}".format(e))
+                    return service_response
+                # We intentionally allow 5xx and uncaught exceptions to bubble up to the caller
+            else:
+                logger.info("All reviews for user_id: {} already indexed".format(user_id))
+
+            # Now kick off an asynchronous scrape for books which also don't exist yet
+            books_in_reviews = [review.book_id for review in user_reviews]
+            books_to_scrape = await self._remove_books_already_indexed(books_in_reviews)
+            for book_id in books_to_scrape:
+                logging.info("Attempting to enqueue book_id: %s", book_id)
+                task_name = self.task_client.enqueue_book(book_id)
+                service_response.tasks.append(task_name)
+
+        return service_response
+
+    async def _remove_reviews_already_indexed(self, user_id,
+                                              user_reviews: List[PubSubUserReviewV1]) -> List[PubSubUserReviewV1]:
+        candidates = user_reviews.copy()
         books_read_by_user = await self.book_recommender_api_client.get_books_read_by_user(user_id)
-        return book_id not in books_read_by_user
+        books_read_by_user_set = set(books_read_by_user)
+        for review in candidates:
+            if review.book_id in books_read_by_user_set:
+                candidates.remove(review)
+        return candidates
+
+    async def _remove_books_already_indexed(self, books_in_reviews: List[int]) -> List[int]:
+        candidates = books_in_reviews.copy()
+        books_in_api = await self.book_recommender_api_client.get_already_indexed_books(books_in_reviews)
+        books_in_api_set = set(books_in_api)
+        for book_id in candidates:
+            if book_id in books_in_api_set:
+                candidates.remove(book_id)
+        return candidates
 
 
 def get_user_review_service(

--- a/tests/clients/test_book_recommender_api_client.py
+++ b/tests/clients/test_book_recommender_api_client.py
@@ -104,7 +104,7 @@ async def test_successful_get_books_read(httpx_mock, caplog: LogCaptureFixture,
     httpx_mock.add_response(json={"book_ids": [3, 4, 5]}, status_code=200, url="https://testurl/users/1/book-ids")
 
     # When
-    response = await book_recommender_api_client.get_books_read_by_user(1)
+    response = await book_recommender_api_client.get_already_indexed_books(1)
 
     # Then
     assert_that(response).contains_only(3, 4, 5)
@@ -120,9 +120,9 @@ async def test_cache_prevent_more_than_one_call_to_get_books_read_by_user(httpx_
 
     # When
     for _ in range(0, 10):
-        await book_recommender_api_client.get_books_read_by_user(1)
+        await book_recommender_api_client.get_already_indexed_books(1)
 
-    await book_recommender_api_client.get_books_read_by_user(2)
+    await book_recommender_api_client.get_already_indexed_books(2)
 
     # Then
     assert_that(httpx_mock.get_requests()).is_length(2)
@@ -137,7 +137,7 @@ async def test_4xx_when_getting_books_read_returns_empty_array(httpx_mock, caplo
     httpx_mock.add_response(status_code=404, url="https://testurl/users/1/book-ids")
 
     # When
-    response = await book_recommender_api_client.get_books_read_by_user(1)
+    response = await book_recommender_api_client.get_already_indexed_books(1)
 
     # Then
     assert_that(caplog.text).contains("Received 4xx exception from server", "user_id: 1",
@@ -154,7 +154,7 @@ async def test_4xx_still_gets_cached(httpx_mock, caplog: LogCaptureFixture,
 
     # When
     for _ in range(10):
-        response = await book_recommender_api_client.get_books_read_by_user(1)
+        response = await book_recommender_api_client.get_already_indexed_books(1)
 
     # Then
     assert_that(caplog.text).contains("Received 4xx exception from server", "user_id: 1",
@@ -172,7 +172,7 @@ async def test_5xx_when_getting_books_read_throws_exception(httpx_mock, caplog: 
 
     # When / Then
     with pytest.raises(BookRecommenderApiServerException):
-        await book_recommender_api_client.get_books_read_by_user(1)
+        await book_recommender_api_client.get_already_indexed_books(1)
 
     assert_that(caplog.text).contains("Received 5xx exception from server", "user_id: 1",
                                       "https://testurl/users/1/book-ids")
@@ -187,7 +187,7 @@ async def test_unhandled_exceptions_when_getting_books_read_throws_exception(htt
 
     # When / Then
     with pytest.raises(BookRecommenderApiServerException) as e:
-        await book_recommender_api_client.get_books_read_by_user(1)
+        await book_recommender_api_client.get_already_indexed_books(1)
 
     assert_that(e.value.args[0]).contains("Unable to read within timeout", "https://testurl/users/1/book-ids")
 
@@ -303,7 +303,7 @@ async def test_successful_user_review_creation(httpx_mock, caplog: LogCaptureFix
     review = _a_random_review()
 
     # When
-    await book_recommender_api_client.create_user_review(review)
+    await book_recommender_api_client.create_batch_user_reviews(review)
 
     # Then
     assert_that(caplog.text).contains("Successfully wrote review", "user_id: 1", "book_id: 2")
@@ -319,7 +319,7 @@ async def test_4xx_user_review_creation_throws_exception(httpx_mock, caplog: Log
 
     # When / Then
     with pytest.raises(BookRecommenderApiClientException):
-        await book_recommender_api_client.create_user_review(review)
+        await book_recommender_api_client.create_batch_user_reviews(review)
 
     assert_that(caplog.text).contains("Received 4xx exception from server", "user_id: 1", "book_id: 2",
                                       "https://testurl/users/1/reviews/2")
@@ -335,7 +335,7 @@ async def test_5xx_user_review_creation_throws_exception(httpx_mock, caplog: Log
 
     # When / Then
     with pytest.raises(BookRecommenderApiServerException):
-        await book_recommender_api_client.create_user_review(review)
+        await book_recommender_api_client.create_batch_user_reviews(review)
 
     assert_that(caplog.text).contains("Received 5xx exception from server", "user_id: 1", "book_id: 2",
                                       "https://testurl/users/1/reviews/2")
@@ -352,7 +352,7 @@ async def test_unhandled_exceptions_when_creating_user_review_throws_exception(h
 
     # When / Then
     with pytest.raises(BookRecommenderApiServerException) as e:
-        await book_recommender_api_client.create_user_review(review)
+        await book_recommender_api_client.create_batch_user_reviews(review)
 
     assert_that(e.value.args[0]).contains("Unable to read within timeout", "https://testurl/users/1/reviews/2 ",
                                           "user_id: 1 book_id: 2")
@@ -367,7 +367,7 @@ async def test_successful_user_review_creation(httpx_mock, caplog: LogCaptureFix
     review = _a_random_review()
 
     # When
-    await book_recommender_api_client.create_user_review(review)
+    await book_recommender_api_client.create_batch_user_reviews(review)
 
     # Then
     assert_that(caplog.text).contains("Successfully wrote review", "user_id: 1", "book_id: 2")

--- a/tests/clients/test_book_recommender_api_client.py
+++ b/tests/clients/test_book_recommender_api_client.py
@@ -233,7 +233,7 @@ async def test_cache_prevent_more_than_one_call_to_check_if_book_exists(httpx_mo
 
 
 @pytest.mark.asyncio
-async def test_cache_doesnt_save_on_empty_response(httpx_mock,
+async def test_cache_doesnt_save_on_empty_book_response(httpx_mock,
                                                    book_recommender_api_client: BookRecommenderApiClient):
     # Given
     httpx_mock.add_response(json={"book_ids": []}, status_code=200, url="https://testurl/books/batch/exists")

--- a/tests/integ/integ_utils.py
+++ b/tests/integ/integ_utils.py
@@ -1,0 +1,7 @@
+import base64
+
+
+def _base_64_encode(input_json: str):
+    doc_bytes = input_json.encode("utf-8")
+    doc_encoded = base64.b64encode(doc_bytes)
+    return str(doc_encoded, 'utf-8')

--- a/tests/integ/test_books_integration_test.py
+++ b/tests/integ/test_books_integration_test.py
@@ -1,6 +1,4 @@
-import base64
 import json
-import logging
 import os
 from pathlib import Path
 
@@ -39,10 +37,10 @@ def test_handle_endpoint_rejects_non_book_objects(test_client: TestClient):
 def test_book_recommender_client_error_suppressed(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture):
     # Given
     _put_call_receives_4xx(httpx_mock)
-    caplog.set_level(logging.ERROR, logger="pubsub_books")
+    payload = json.dumps({"items": [_a_random_book_dict()]})
+
     message = _an_example_pubsub_post_call()
-    payload = {"items": (_get_book_in_json())}
-    message["message"]["data"] = _get_book_in_json()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/books/handle", json=message)
@@ -55,9 +53,10 @@ def test_book_recommender_client_error_suppressed(httpx_mock, test_client: TestC
 def test_book_recommender_server_error_propagates(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture):
     # Given
     _put_call_receives_5xx(httpx_mock)
-    caplog.set_level(logging.ERROR, logger="pubsub_books")
+    payload = json.dumps({"items": [_a_random_book_dict()]})
+
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _get_book_in_json()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/books/handle", json=message)
@@ -69,24 +68,26 @@ def test_book_recommender_server_error_propagates(httpx_mock, test_client: TestC
 
 def test_well_formed_request_but_not_a_valid_book_returns_200(test_client: TestClient, caplog: LogCaptureFixture):
     # Given
-    caplog.set_level(logging.ERROR, logger="pubsub_books")
+    payload = json.dumps({"items": [{"abc": 123}]})
+
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_random_json_object()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/books/handle", json=message)
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(caplog.text).contains("Error converting payload into book object")
+    assert_that(caplog.text).contains("Error converting item into PubSubBookV1 object")
 
 
 def test_successful_book_write(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture):
     # Given
     _put_call_is_successful(httpx_mock)
-    caplog.set_level(logging.INFO, logger="pubsub_books")
+    payload = json.dumps({"items": [_a_random_book_dict()]})
+
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _get_book_in_json()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/books/handle", json=message)
@@ -94,18 +95,112 @@ def test_successful_book_write(httpx_mock, test_client: TestClient, caplog: LogC
     # Then
     assert_that(response.status_code).is_equal_to(200)
     assert_that(caplog.text).contains("Successfully wrote book: 4")
+    assert_that(response.json().get("indexed")).is_equal_to(1)
 
 
-def _put_call_is_successful(httpx_mock):
-    httpx_mock.add_response(status_code=200, url="http://localhost:9000/books/4", method="PUT")
+def test_invalid_item_in_batch_doesnt_prevent_other_writes(httpx_mock, test_client: TestClient,
+                                                           caplog: LogCaptureFixture):
+    # Given
+    _put_call_is_successful(httpx_mock)
+    payload = json.dumps({"items": [_a_random_book_dict(), {"abc": 123}]})
+
+    message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _base_64_encode(payload)
+
+    # When
+    response = test_client.post("/pubsub/books/handle", json=message)
+
+    # Then
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(caplog.text).contains("Successfully wrote book: 4")
+    assert_that(response.json().get("indexed")).is_equal_to(1)
 
 
-def _put_call_receives_4xx(httpx_mock):
-    httpx_mock.add_response(status_code=422, url="http://localhost:9000/books/4", method="PUT")
+def test_multiple_valid_books_with_successful_puts(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture):
+    # Given
+    _put_call_is_successful(httpx_mock, 1)
+    _put_call_is_successful(httpx_mock, 2)
+
+    book_1 = _a_random_book_dict()
+    book_1["book_id"] = 1
+
+    book_2 = _a_random_book_dict()
+    book_2["book_id"] = 2
+
+    payload = json.dumps({"items": [book_1, book_2]})
+
+    message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _base_64_encode(payload)
+
+    # When
+    response = test_client.post("/pubsub/books/handle", json=message)
+
+    # Then
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(caplog.text).contains("Successfully wrote book: 1", "Successfully wrote book: 2")
+    assert_that(response.json().get("indexed")).is_equal_to(2)
 
 
-def _put_call_receives_5xx(httpx_mock):
-    httpx_mock.add_response(status_code=500, url="http://localhost:9000/books/4", method="PUT")
+def test_multiple_valid_books_with_one_4xx_put_fails_gracefully(httpx_mock, test_client: TestClient,
+                                                                caplog: LogCaptureFixture):
+    # Given
+    _put_call_is_successful(httpx_mock, 1)
+    _put_call_receives_4xx(httpx_mock, 2)
+
+    book_1 = _a_random_book_dict()
+    book_1["book_id"] = 1
+
+    book_2 = _a_random_book_dict()
+    book_2["book_id"] = 2
+
+    payload = json.dumps({"items": [book_1, book_2]})
+
+    message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _base_64_encode(payload)
+
+    # When
+    response = test_client.post("/pubsub/books/handle", json=message)
+
+    # Then
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(caplog.text).contains("Successfully wrote book: 1")
+    assert_that(response.json().get("indexed")).is_equal_to(1)
+
+
+def test_multiple_valid_books_with_one_5xx_put_fails_entire_batch(httpx_mock, test_client: TestClient,
+                                                                  caplog: LogCaptureFixture):
+    # Given
+    _put_call_is_successful(httpx_mock, 1)
+    _put_call_receives_5xx(httpx_mock, 2)
+
+    book_1 = _a_random_book_dict()
+    book_1["book_id"] = 1
+
+    book_2 = _a_random_book_dict()
+    book_2["book_id"] = 2
+
+    payload = json.dumps({"items": [book_1, book_2]})
+
+    message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _base_64_encode(payload)
+
+    # When
+    response = test_client.post("/pubsub/books/handle", json=message)
+
+    # Then
+    assert_that(response.status_code).is_equal_to(500)
+
+
+def _put_call_is_successful(httpx_mock, book_id=4):
+    httpx_mock.add_response(status_code=200, url=f"http://localhost:9000/books/{book_id}", method="PUT")
+
+
+def _put_call_receives_4xx(httpx_mock, book_id=4):
+    httpx_mock.add_response(status_code=422, url=f"http://localhost:9000/books/{book_id}", method="PUT")
+
+
+def _put_call_receives_5xx(httpx_mock, book_id=4):
+    httpx_mock.add_response(status_code=500, url=f"http://localhost:9000/books/{book_id}", method="PUT")
 
 
 def _an_example_pubsub_post_call():
@@ -118,7 +213,7 @@ def _an_example_pubsub_post_call():
     }
 
 
-def _get_book_in_json():
-    with open(file_root_path.parents[0] / "resources/harry_potter.input_json", "r") as f:
+def _a_random_book_dict():
+    with open(file_root_path.parents[0] / "resources/harry_potter.json", "r") as f:
         doc = json.load(f)
         return doc

--- a/tests/integ/test_profiles_integration_test.py
+++ b/tests/integ/test_profiles_integration_test.py
@@ -51,7 +51,7 @@ def test_well_formed_request_but_not_a_valid_profile_returns_200(test_client: Te
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(caplog.text).contains("Error converting profile into PubSubProfileV1 object")
+    assert_that(caplog.text).contains("Error converting item into PubSubProfileV1 object")
 
 
 def test_successful_profile_task_enqueues_correctly(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture,

--- a/tests/integ/test_user_reviews_integration_test.py
+++ b/tests/integ/test_user_reviews_integration_test.py
@@ -1,7 +1,7 @@
-import base64
 import json
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -13,8 +13,12 @@ from google.cloud.tasks_v2 import CloudTasksClient
 from src.clients.book_recommender_api_client import BookRecommenderApiServerException
 from src.main import app
 from src.services.user_review_service import get_user_review_service
+from tests.integ.integ_utils import _base_64_encode
 
 file_root_path = Path(os.path.dirname(__file__))
+
+USER_ID = 1
+BOOK_ID = 2
 
 
 @pytest.fixture
@@ -28,139 +32,195 @@ def test_handle_endpoint_doesnt_allow_gets(test_client: TestClient):
     assert_that(response.status_code).is_equal_to(405)
 
 
-def test_handle_endpoint_rejects_malformed_requests(test_client: TestClient):
-    # Given
-    request = {"malformed_request": 123}
-
-    # When
-    response = test_client.post("/pubsub/user-reviews/handle", json=request)
-
-    # Then
-    assert_that(response.status_code).is_equal_to(422)
-
-
-def test_well_formed_request_but_payload_not_json_returns_200(test_client: TestClient, caplog: LogCaptureFixture):
+def test_well_formed_request_but_not_a_valid_user_review_batch_returns_200(test_client: TestClient,
+                                                                           caplog: LogCaptureFixture):
     # Given
     caplog.set_level(logging.ERROR, logger="pubsub_user_reviews")
+    payload = json.dumps({"items": [{"garbage": "123"}]})
     message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/user-reviews/handle", json=message)
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(caplog.text).contains("Payload was not in JSON")
+    assert_that(caplog.text).contains("Error converting item into PubSubUserReviewV1 object")
 
 
-def test_well_formed_request_but_not_a_valid_user_review_returns_200(test_client: TestClient,
-                                                                     caplog: LogCaptureFixture):
+def test_multiple_review_multiple_book_creation(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture,
+                                                cloud_tasks: CloudTasksClient):
     # Given
-    caplog.set_level(logging.ERROR, logger="pubsub_user_reviews")
+    num_reviews = 5
+    _user_has_read_no_books(httpx_mock)
+    _user_review_batch_create_successful(httpx_mock, 5)
+    _book_doesnt_exist(httpx_mock)
+
+    reviews = [_a_random_user_review(book_id=i) for i in range(num_reviews)]
+    payload = json.dumps({"items": reviews})
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_random_json_object()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/user-reviews/handle", json=message)
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(caplog.text).contains("Error converting payload into user review object")
+    assert_that(caplog.text).contains(f"Successfully indexed {num_reviews} user reviews")
+    assert_that(response.json().get("indexed")).is_equal_to(num_reviews)
+    assert_that(response.json().get("tasks")).is_length(num_reviews)
+
+
+def test_indexer_correctly_takes_into_account_existing_items(httpx_mock, test_client: TestClient,
+                                                             caplog: LogCaptureFixture,
+                                                             cloud_tasks: CloudTasksClient):
+    # Given
+    total_num_reviews = 5
+    expected_num_reviews_indexed = 2
+    expected_num_books_enqueued = 3
+    _user_has_read_books(httpx_mock, [0, 1, 2])
+    _book_exists_in_db(httpx_mock, [3, 4])
+    _user_review_batch_create_successful(httpx_mock, expected_num_reviews_indexed)
+
+    reviews = [_a_random_user_review(book_id=i) for i in range(total_num_reviews)]
+    payload = json.dumps({"items": reviews})
+    message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _base_64_encode(payload)
+
+    # When
+    response = test_client.post("/pubsub/user-reviews/handle", json=message)
+
+    # Then
+    assert_that(response.status_code).is_equal_to(200)
+    assert_that(caplog.text).contains(f"Successfully indexed {expected_num_reviews_indexed} user reviews")
+    assert_that(response.json().get("indexed")).is_equal_to(expected_num_reviews_indexed)
+    assert_that(response.json().get("tasks")).is_length(expected_num_books_enqueued)
+
+
+def test_multiple_users_in_one_batch_doesnt_mess_things_up(httpx_mock, test_client: TestClient,
+                                                           caplog: LogCaptureFixture,
+                                                           cloud_tasks: CloudTasksClient):
+    # Given
+    _user_has_read_no_books(httpx_mock, user_id=1)
+    _user_has_read_books(httpx_mock, book_ids=[1, 2, 3, 4, 5], user_id=2)
+    _user_review_batch_create_successful(httpx_mock, 1)  # A bit sloppy, but both are going to create one item
+    _book_exists_in_db(httpx_mock, book_ids=[1, 2, 3])
+
+    reviews = [_a_random_user_review(user_id=1, book_id=1),  # Unread by user 1
+               _a_random_user_review(user_id=2, book_id=4),  # Read by user 2
+               _a_random_user_review(user_id=2, book_id=6)]  # Unread by user 1
+
+    payload = json.dumps({"items": reviews})
+    message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _base_64_encode(payload)
+
+    # When
+    response = test_client.post("/pubsub/user-reviews/handle", json=message)
+
+    # Then
+    assert_that(response.status_code).is_equal_to(200)
+    # Two separate users should get two separate calls to create user review batches
+    create_calls = [True for message in caplog.messages if message == "Successfully indexed 1 user reviews"]
+    assert_that(create_calls).is_length(2)
+    # But their index count should be aggregated together
+    assert_that(response.json().get("indexed")).is_equal_to(2)
+    # And the number of tasks should be the number of books that need to be enqueued, regardless of who enqueued them
+    assert_that(response.json().get("tasks")).is_length(2)
 
 
 def test_user_review_doesnt_exist_book_exists(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture,
                                               cloud_tasks):
     # Given
-    _user_review_doesnt_exist(httpx_mock)
-    _user_review_put_successful(httpx_mock)
-    _book_exists(httpx_mock)
+    _user_has_read_no_books(httpx_mock)
+    _user_review_batch_create_successful(httpx_mock)
+    _book_exists_in_db(httpx_mock)
 
-    caplog.set_level(logging.INFO, logger="book_recommender_api_client")
+    payload = json.dumps({"items": [_a_random_user_review()]})
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/user-reviews/handle", json=message)
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(caplog.text).contains("Successfully wrote review for user_id: 1 book_id: 13501")
-    assert_that(response.json().get("task_name")).is_none()
+    assert_that(caplog.text).contains(f"Successfully indexed {1} user reviews")
+    assert_that(response.json().get("indexed")).is_equal_to(1)
+    assert_that(response.json().get("tasks")).is_length(0)
 
 
 def test_user_review_exists_book_doesnt_exist(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture,
                                               cloud_tasks):
     # Given
-    _user_review_exists(httpx_mock)
+    _user_has_read_books(httpx_mock)
     _book_doesnt_exist(httpx_mock)
+    payload = json.dumps({"items": [_a_random_user_review()]})
 
-    caplog.set_level(logging.INFO, logger="book_recommender_api_client")
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/user-reviews/handle", json=message)
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(cloud_tasks.get_task(name=response.json().get("task_name"))).is_not_none()
+    assert_that(response.json().get("indexed")).is_equal_to(0)
+    assert_that(response.json().get("tasks")).is_length(1)
 
 
 def test_user_review_exists_book_exists(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture, cloud_tasks):
     # Given
-    _user_review_exists(httpx_mock)
-    _book_exists(httpx_mock)
+    _user_has_read_books(httpx_mock)
+    _book_exists_in_db(httpx_mock)
+    payload = json.dumps({"items": [_a_random_user_review()]})
 
-    caplog.set_level(logging.INFO, logger="book_recommender_api_client")
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/user-reviews/handle", json=message)
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(response.json().get("task_name")).is_none()
+    assert_that(response.json().get("indexed")).is_equal_to(0)
+    assert_that(response.json().get("tasks")).is_length(0)
 
 
 def test_user_review_doesnt_exist_book_doesnt_exist(httpx_mock, test_client: TestClient, caplog: LogCaptureFixture,
                                                     cloud_tasks: CloudTasksClient):
     # Given
-    _user_review_doesnt_exist(httpx_mock)
-    _user_review_put_successful(httpx_mock)
+    _user_has_read_no_books(httpx_mock)
+    _user_review_batch_create_successful(httpx_mock)
     _book_doesnt_exist(httpx_mock)
+    payload = json.dumps({"items": [_a_random_user_review()]})
 
-    caplog.set_level(logging.INFO, logger="book_recommender_api_client")
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     response = test_client.post("/pubsub/user-reviews/handle", json=message)
 
     # Then
     assert_that(response.status_code).is_equal_to(200)
-    assert_that(caplog.text).contains("Successfully wrote review for user_id: 1 book_id: 13501")
-    assert_that(cloud_tasks.get_task(name=response.json().get("task_name"))).is_not_none()
+    assert_that(response.json().get("indexed")).is_equal_to(1)
+    assert_that(response.json().get("tasks")).is_length(1)
 
 
-def test_user_review_doesnt_exist_but_put_receives_client_error_handled_gracefully(httpx_mock, test_client: TestClient,
-                                                                                   caplog: LogCaptureFixture,
-                                                                                   cloud_tasks: CloudTasksClient):
+def test_user_review_doesnt_exist_and_we_get_429_response(httpx_mock, test_client: TestClient,
+                                                          caplog: LogCaptureFixture,
+                                                          cloud_tasks: CloudTasksClient):
     # Given
-    _user_review_doesnt_exist(httpx_mock)
-    _user_review_put_gets_client_error(httpx_mock)
+    _user_has_read_no_books(httpx_mock)
+    _user_review_batch_create_gets_too_many_requests_response(httpx_mock)
+    payload = json.dumps({"items": [_a_random_user_review()]})
 
-    caplog.set_level(logging.ERROR, logger="user_review_service")
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
-    response = test_client.post("/pubsub/user-reviews/handle", json=message)
-
-    # Then
-    assert_that(response.status_code).is_equal_to(200)
-    assert_that(caplog.text).contains("Received 4xx response from API - Failed to index user review")
-    assert_that(response.json().get("index_review")).is_none()
-    assert_that(response.json().get("task_name")).is_none()
+    with pytest.raises(BookRecommenderApiServerException):
+        response = test_client.post("/pubsub/user-reviews/handle", json=message)
+        assert_that(response.status_code).is_equal_to(500)
 
 
 def test_user_review_doesnt_exist_put_receives_server_error_propagates_exception_back(httpx_mock,
@@ -168,17 +228,17 @@ def test_user_review_doesnt_exist_put_receives_server_error_propagates_exception
                                                                                       caplog: LogCaptureFixture,
                                                                                       cloud_tasks: CloudTasksClient):
     # Given
-    _user_review_doesnt_exist(httpx_mock)
-    _user_review_put_gets_server_error(httpx_mock)
+    _user_has_read_no_books(httpx_mock)
+    _user_review_batch_create_gets_server_error(httpx_mock)
+    payload = json.dumps({"items": [_a_random_user_review()]})
 
-    caplog.set_level(logging.ERROR, logger="user_review_service")
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     with pytest.raises(BookRecommenderApiServerException):
         response = test_client.post("/pubsub/user-reviews/handle", json=message)
-        assert response.status_code == 500
+        assert_that(response.status_code).is_equal_to(500)
 
 
 def test_book_existence_check_throwing_500_propagates_error_upward(httpx_mock,
@@ -186,17 +246,18 @@ def test_book_existence_check_throwing_500_propagates_error_upward(httpx_mock,
                                                                    caplog: LogCaptureFixture,
                                                                    cloud_tasks: CloudTasksClient):
     # Given
-    _user_review_doesnt_exist(httpx_mock)
-    _user_review_put_successful(httpx_mock)
+    _user_has_read_no_books(httpx_mock)
+    _user_review_batch_create_successful(httpx_mock)
     _book_existence_check_throws_server_error(httpx_mock)
 
+    payload = json.dumps({"items": [_a_random_user_review()]})
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     with pytest.raises(BookRecommenderApiServerException):
         response = test_client.post("/pubsub/user-reviews/handle", json=message)
-        assert response.status_code == 500
+        assert_that(response.status_code).is_equal_to(500)
 
 
 def test_user_review_existence_check_throwing_500_propagates_error_upward(httpx_mock,
@@ -206,8 +267,9 @@ def test_user_review_existence_check_throwing_500_propagates_error_upward(httpx_
     # Given
     _user_review_existence_check_throws_server_error(httpx_mock)
 
+    payload = json.dumps({"items": [_a_random_user_review()]})
     message = _an_example_pubsub_post_call()
-    message["message"]["data"] = _a_base_64_encoded_user_review()
+    message["message"]["data"] = _base_64_encode(payload)
 
     # When
     with pytest.raises(BookRecommenderApiServerException):
@@ -215,40 +277,46 @@ def test_user_review_existence_check_throwing_500_propagates_error_upward(httpx_
         assert response.status_code == 500
 
 
-def _user_review_exists(httpx_mock):
-    httpx_mock.add_response(json={"book_ids": [13501]}, status_code=200, url="http://localhost:9000/users/1/book-ids")
+def _user_has_read_books(httpx_mock, book_ids=[BOOK_ID], user_id=USER_ID):
+    httpx_mock.add_response(json={"book_ids": book_ids}, status_code=200,
+                            url=f"http://localhost:9000/users/{user_id}/book-ids")
 
 
-def _user_review_doesnt_exist(httpx_mock):
-    httpx_mock.add_response(json={"book_ids": []}, status_code=200, url="http://localhost:9000/users/1/book-ids")
+def _user_has_read_no_books(httpx_mock, user_id=USER_ID):
+    httpx_mock.add_response(json={"book_ids": []}, status_code=200,
+                            url=f"http://localhost:9000/users/{user_id}/book-ids")
 
 
 def _user_review_existence_check_throws_server_error(httpx_mock):
     httpx_mock.add_response(status_code=500, url="http://localhost:9000/users/1/book-ids")
 
 
-def _book_exists(httpx_mock):
-    httpx_mock.add_response(status_code=200, url="http://localhost:9000/books/13501")
+def _book_exists_in_db(httpx_mock, book_ids=[BOOK_ID]):
+    httpx_mock.add_response(json={"book_ids": book_ids}, status_code=200,
+                            url="http://localhost:9000/books/batch/exists",
+                            method="POST")
 
 
 def _book_doesnt_exist(httpx_mock):
-    httpx_mock.add_response(status_code=404, url="http://localhost:9000/books/13501")
+    httpx_mock.add_response(json={"book_ids": []}, status_code=200, url="http://localhost:9000/books/batch/exists",
+                            method="POST")
 
 
 def _book_existence_check_throws_server_error(httpx_mock):
-    httpx_mock.add_response(status_code=500, url="http://localhost:9000/books/13501")
+    httpx_mock.add_response(status_code=500, url="http://localhost:9000/books/batch/exists", method="POST")
 
 
-def _user_review_put_successful(httpx_mock):
-    httpx_mock.add_response(status_code=200, url=f"http://localhost:9000/users/1/reviews/13501")
+def _user_review_batch_create_successful(httpx_mock, indexed=1):
+    httpx_mock.add_response(json={"indexed": indexed}, status_code=200, url=f"http://localhost:9000/users/batch/create",
+                            method="POST")
 
 
-def _user_review_put_gets_client_error(httpx_mock):
-    httpx_mock.add_response(status_code=422, url=f"http://localhost:9000/users/1/reviews/13501")
+def _user_review_batch_create_gets_too_many_requests_response(httpx_mock):
+    httpx_mock.add_response(status_code=429, url=f"http://localhost:9000/users/batch/create", method="POST")
 
 
-def _user_review_put_gets_server_error(httpx_mock):
-    httpx_mock.add_response(status_code=500, url=f"http://localhost:9000/users/1/reviews/13501")
+def _user_review_batch_create_gets_server_error(httpx_mock):
+    httpx_mock.add_response(status_code=500, url=f"http://localhost:9000/users/batch/create", method="POST")
 
 
 def _stub_user_review_service(user_review_service):
@@ -265,16 +333,11 @@ def _an_example_pubsub_post_call():
     }
 
 
-def _a_base_64_encoded_random_json_object():
-    random_json = {"random": "json"}
-    doc_bytes = json.dumps(random_json).encode("utf-8")
-    doc_encoded = base64.b64encode(doc_bytes)
-    return str(doc_encoded, 'utf-8')
-
-
-def _a_base_64_encoded_user_review():
-    with open(file_root_path.parents[0] / "resources/hedge_knight_user_review.json", "r") as f:
-        doc = json.load(f)
-        doc_bytes = json.dumps(doc).encode("utf-8")
-        doc_encoded = base64.b64encode(doc_bytes)
-        return str(doc_encoded, 'utf-8')
+def _a_random_user_review(user_id: int = USER_ID, book_id: int = BOOK_ID):
+    return {
+        "user_id": user_id,
+        "book_id": book_id,
+        "user_rating": 5,
+        "date_read": "2017-09-29T00:00:00",
+        "scrape_time": datetime.now().isoformat(),
+    }

--- a/tests/services/test_user_review_service.py
+++ b/tests/services/test_user_review_service.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 import pytest
 from assertpy import assert_that
 
+from src.clients.api_models import UserReviewBatchResponse
 from src.clients.book_recommender_api_client import BookRecommenderApiClient
 from src.clients.task_client import TaskClient
 from src.routes.pubsub_models import PubSubUserReviewV1
@@ -16,8 +17,9 @@ BOOK_ID = 2
 def book_recommender_api_client():
     with patch('src.clients.book_recommender_api_client') as mock_book_recommender_api_client:
         mock_book_recommender_api_client.get_books_read_by_user = AsyncMock(return_value=[])
-        mock_book_recommender_api_client.does_book_exist = AsyncMock(return_value=False)
-        mock_book_recommender_api_client.create_user_review = AsyncMock(return_value=None)
+        mock_book_recommender_api_client.get_already_indexed_books = AsyncMock(return_value=[])
+        mock_book_recommender_api_client.create_batch_user_reviews = AsyncMock(
+            return_value=UserReviewBatchResponse(indexed=0))
         yield mock_book_recommender_api_client
 
 
@@ -33,19 +35,41 @@ async def test_review_exists_book_exists(book_recommender_api_client: BookRecomm
                                          task_client: TaskClient):
     # Given
     book_recommender_api_client.get_books_read_by_user = AsyncMock(return_value=[BOOK_ID])
-    book_recommender_api_client.does_book_exist = AsyncMock(return_value=True)
+    book_recommender_api_client.get_already_indexed_books = AsyncMock(return_value=[BOOK_ID])
     service = UserReviewService(book_recommender_api_client, task_client)
-    review = _a_pubsub_user_review()
+    reviews_to_index = [_a_pubsub_user_review()]
 
     # When
-    response = await service.process_pubsub_message(review)
+    response = await service.process_pubsub_batch_message(reviews_to_index)
 
     # Then
-    assert_that(response.indexed_review).is_false()
-    assert_that(response.task_name).is_none()
+    assert_that(response.indexed).is_equal_to(0)
+    assert_that(response.tasks).is_empty()
 
-    book_recommender_api_client.create_user_review.assert_not_called()
+    book_recommender_api_client.create_batch_user_reviews.assert_not_called()
     task_client.enqueue_book.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_one_review_exists_one_book_exists(book_recommender_api_client: BookRecommenderApiClient,
+                                                 task_client: TaskClient):
+    # Given
+    new_book_id = 5
+    book_recommender_api_client.get_books_read_by_user = AsyncMock(return_value=[BOOK_ID])
+    book_recommender_api_client.get_already_indexed_books = AsyncMock(return_value=[BOOK_ID])
+    book_recommender_api_client.create_batch_user_reviews = AsyncMock(return_value=UserReviewBatchResponse(indexed=1))
+    service = UserReviewService(book_recommender_api_client, task_client)
+    reviews_to_index = [_a_pubsub_user_review(book_id=BOOK_ID), _a_pubsub_user_review(book_id=new_book_id)]
+
+    # When
+    response = await service.process_pubsub_batch_message(reviews_to_index)
+
+    # Then
+    assert_that(response.indexed).is_equal_to(1)
+    assert_that(response.tasks).is_length(1)
+
+    book_recommender_api_client.create_batch_user_reviews.assert_called_once()
+    task_client.enqueue_book.assert_called_with(new_book_id)
 
 
 @pytest.mark.asyncio
@@ -53,17 +77,19 @@ async def test_review_doesnt_exist_book_exists(book_recommender_api_client: Book
                                                task_client: TaskClient):
     # Given
     book_recommender_api_client.get_books_read_by_user = AsyncMock(return_value=[])
-    book_recommender_api_client.does_book_exist = AsyncMock(return_value=True)
+    book_recommender_api_client.get_already_indexed_books = AsyncMock(return_value=[BOOK_ID])
+    book_recommender_api_client.create_batch_user_reviews = AsyncMock(return_value=UserReviewBatchResponse(indexed=1))
     service = UserReviewService(book_recommender_api_client, task_client)
-    review = _a_pubsub_user_review()
+    reviews = [_a_pubsub_user_review()]
 
     # When
-    response = await service.process_pubsub_message(review)
+    response = await service.process_pubsub_batch_message(reviews)
 
     # Then
-    assert_that(response.indexed_review).is_true()
-    assert_that(response.task_name).is_none()
-    book_recommender_api_client.create_user_review.assert_called_with(review.dict())
+    assert_that(response.indexed).is_equal_to(1)
+    assert_that(response.tasks).is_empty()
+
+    book_recommender_api_client.create_batch_user_reviews.assert_called_once()
     task_client.enqueue_book.assert_not_called()
 
 
@@ -72,17 +98,19 @@ async def test_review_exists_book_doesnt_exist(book_recommender_api_client: Book
                                                task_client: TaskClient):
     # Given
     book_recommender_api_client.get_books_read_by_user = AsyncMock(return_value=[BOOK_ID])
-    book_recommender_api_client.does_book_exist = AsyncMock(return_value=False)
+    book_recommender_api_client.get_already_indexed_books = AsyncMock(return_value=[])
+
     service = UserReviewService(book_recommender_api_client, task_client)
-    review = _a_pubsub_user_review()
+    reviews = [_a_pubsub_user_review()]
 
     # When
-    response = await service.process_pubsub_message(review)
+    response = await service.process_pubsub_batch_message(reviews)
 
     # Then
-    assert_that(response.indexed_review).is_false()
-    assert_that(response.task_name).is_equal_to("foo")
-    book_recommender_api_client.create_user_review.assert_not_called()
+    assert_that(response.indexed).is_equal_to(0)
+    assert_that(response.tasks).is_length(1)
+
+    book_recommender_api_client.create_batch_user_reviews.assert_not_called()
     task_client.enqueue_book.assert_called_with(BOOK_ID)
 
 
@@ -91,25 +119,51 @@ async def test_review_doesnt_exist_book_doesnt_exist(book_recommender_api_client
                                                      task_client: TaskClient):
     # Given
     book_recommender_api_client.get_books_read_by_user = AsyncMock(return_value=[])
-    book_recommender_api_client.does_book_exist = AsyncMock(return_value=False)
+    book_recommender_api_client.get_already_indexed_books = AsyncMock(return_value=[])
+    book_recommender_api_client.create_batch_user_reviews = AsyncMock(return_value=UserReviewBatchResponse(indexed=1))
 
     service = UserReviewService(book_recommender_api_client, task_client)
-    review = _a_pubsub_user_review()
+    reviews = [_a_pubsub_user_review()]
 
     # When
-    response = await service.process_pubsub_message(review)
+    response = await service.process_pubsub_batch_message(reviews)
 
     # Then
-    assert_that(response.indexed_review).is_true()
-    assert_that(response.task_name).is_equal_to("foo")
-    book_recommender_api_client.create_user_review.assert_called_with(review.dict())
+    assert_that(response.indexed).is_equal_to(1)
+    assert_that(response.tasks).is_length(1)
+
+    book_recommender_api_client.create_batch_user_reviews.assert_called_once()
     task_client.enqueue_book.assert_called_with(BOOK_ID)
 
 
-def _a_pubsub_user_review():
+@pytest.mark.asyncio
+async def test_multiple_books_multiple_reviews_indexed(book_recommender_api_client: BookRecommenderApiClient,
+                                                       task_client: TaskClient):
+    # Given
+    book_recommender_api_client.get_books_read_by_user = AsyncMock(return_value=[])
+    book_recommender_api_client.get_already_indexed_books = AsyncMock(return_value=[])
+    book_recommender_api_client.create_batch_user_reviews = AsyncMock(return_value=UserReviewBatchResponse(indexed=3))
+
+    service = UserReviewService(book_recommender_api_client, task_client)
+    reviews = []
+    for i in range(5):
+        reviews.append(_a_pubsub_user_review(book_id=BOOK_ID + i))
+
+    # When
+    response = await service.process_pubsub_batch_message(reviews)
+
+    # Then
+    assert_that(response.indexed).is_equal_to(3)
+    assert_that(response.tasks).is_length(len(reviews))
+
+    book_recommender_api_client.create_batch_user_reviews.assert_called_once()
+    assert_that(task_client.enqueue_book.call_count).is_equal_to(len(reviews))
+
+
+def _a_pubsub_user_review(user_id: int = USER_ID, book_id: int = BOOK_ID):
     return PubSubUserReviewV1(
-        user_id=USER_ID,
-        book_id=BOOK_ID,
+        user_id=user_id,
+        book_id=book_id,
         user_rating=3,
         date_read="2022-01-01",
         scrape_time="2022-03-12T12:00:00"

--- a/tests/test_pubsub_utils.py
+++ b/tests/test_pubsub_utils.py
@@ -1,0 +1,45 @@
+import logging
+
+from _pytest.logging import LogCaptureFixture
+from assertpy import assert_that
+from fastapi.testclient import TestClient
+
+from src.routes.pubsub_models import PubSubMessage
+from src.routes.pubsub_utils import _unpack_envelope
+
+
+def test_well_formed_request_but_payload_not_json_returns_200(test_client: TestClient, caplog: LogCaptureFixture):
+    # Given
+    message = _an_example_pubsub_post_call()
+    pub_sub_message = PubSubMessage(**message)
+
+    # When
+    _unpack_envelope(pub_sub_message)
+
+    # Then
+    assert_that(caplog.text).contains("Payload was not in JSON")
+
+
+def test_handle_endpoint_logs_error_but_suppresses_exception(test_client: TestClient, caplog: LogCaptureFixture):
+    message = _an_example_pubsub_post_call()
+    message["message"]["data"] = _invalid_base_64_object()
+    pub_sub_message = PubSubMessage(**message)
+
+    _unpack_envelope(pub_sub_message)
+
+    assert_that(caplog.text).contains("Uncaught Exception", "Incorrect padding", _invalid_base_64_object())
+
+
+def _invalid_base_64_object():
+    # incorrectly padded base 64 object - should throw a gnarly error
+    return "ABHPdSaxrhjAWA="
+
+
+def _an_example_pubsub_post_call():
+    return {
+        "message": {
+            "data": "SGVsbG8gQ2xvdWQgUHViL1N1YiEgSGVyZSBpcyBteSBtZXNzYWdlIQ==",
+            "message_id": "2070443601311540",
+            "publish_time": "2021-02-26T19:13:55.749Z"},
+        "subscription": "projects/myproject/subscriptions/mysubscription"
+    }


### PR DESCRIPTION
Reworked the way we get messages from pubsub. Now they come in batches, so we can do more per API request. The last system I had generated WAY too many requests per second, which were easy to process, but ultimately redundant. 

This PR now expects every pubsub message to be batched like this

```json
items: [{item_json": "goes_here"}]
```

I also

- Abstracted out the envelope unpacking from PubSub now that they all follow the same wrapper 
- Tweaked a few of our methods to now allow for batching, which certainly made them more complicated (and more "for loopy"
- Leveraged BatchReviewExists and Batch User Review Create on the book recommender API 🙌 