### PR TITLE
Don't create tasks which already exist

### DIFF
--- a/tests/clients/test_task_client.py
+++ b/tests/clients/test_task_client.py
@@ -4,11 +4,13 @@ from google.cloud.tasks_v2 import CloudTasksClient
 from src.clients.task_client import TaskClient
 from src.dependencies import Properties
 
+default_properties = Properties()
+PARENT_QUEUE = f"projects/{default_properties.gcp_project_name}/locations/{default_properties.cloud_task_region}/queues/{default_properties.task_queue_name}"
+
 
 def test_task_client_ready_validates_our_queues_exist(cloud_tasks: CloudTasksClient):
     # Given
-    properties = Properties()
-    task_client = TaskClient(cloud_tasks, properties)
+    task_client = TaskClient(cloud_tasks, default_properties)
 
     # When
     response = task_client.is_ready()
@@ -27,3 +29,31 @@ def test_task_client_fails_with_unknown_queue(cloud_tasks: CloudTasksClient):
 
     # Then
     assert_that(response).is_false()
+
+
+def test_task_queue_successfully_deduplicates_user_tasks(cloud_tasks: CloudTasksClient):
+    # Given
+    task_client = TaskClient(cloud_tasks, default_properties)
+
+    # When
+    task_name = task_client.enqueue_user_scrape("abc123")
+    task_name_2 = task_client.enqueue_user_scrape("abc123")
+
+    # Then
+    assert_that(task_name).is_equal_to(f"{PARENT_QUEUE}/tasks/user-abc123")
+    assert_that(task_name_2).is_none()
+    assert_that(list(cloud_tasks.list_tasks(parent=PARENT_QUEUE))).is_length(1)
+
+
+def test_task_queue_successfully_deduplicates_book_tasks(cloud_tasks: CloudTasksClient):
+    # Given
+    task_client = TaskClient(cloud_tasks, default_properties)
+
+    # When
+    task_name = task_client.enqueue_book(12345)
+    task_name_2 = task_client.enqueue_book(12345)
+
+    # Then
+    assert_that(task_name).is_equal_to(f"{PARENT_QUEUE}/tasks/book-12345")
+    assert_that(task_name_2).is_none()
+    assert_that(list(cloud_tasks.list_tasks(parent=PARENT_QUEUE))).is_length(1)

--- a/tests/clients/test_task_client.py
+++ b/tests/clients/test_task_client.py
@@ -41,7 +41,7 @@ def test_task_queue_successfully_deduplicates_user_tasks(cloud_tasks: CloudTasks
 
     # Then
     assert_that(task_name).is_equal_to(f"{PARENT_QUEUE}/tasks/user-abc123")
-    assert_that(task_name_2).is_none()
+    assert_that(task_name_2).is_equal_to("duplicate")
     assert_that(list(cloud_tasks.list_tasks(parent=PARENT_QUEUE))).is_length(1)
 
 
@@ -55,5 +55,5 @@ def test_task_queue_successfully_deduplicates_book_tasks(cloud_tasks: CloudTasks
 
     # Then
     assert_that(task_name).is_equal_to(f"{PARENT_QUEUE}/tasks/book-12345")
-    assert_that(task_name_2).is_none()
+    assert_that(task_name_2).is_equal_to("duplicate")
     assert_that(list(cloud_tasks.list_tasks(parent=PARENT_QUEUE))).is_length(1)


### PR DESCRIPTION
Let's utilize the cloud tasks name to make sure we don't queue up redundant scrapes (we did this a lot...)